### PR TITLE
refractored algorithim & changed score data-type from int to double

### DIFF
--- a/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Controllers/StatusController.java
+++ b/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Controllers/StatusController.java
@@ -45,7 +45,7 @@ public class StatusController {
         VaccineDataDTO vaccineStats = covidApiService.getAllVaccineDataByCountry(country).getBody();
 
         status.setLocation(country);
-        status.setScore(statusService.calculateScore(covidStats,vaccineStats));
+        status.setScore(statusService.calculateScore(covidStats, vaccineStats));
         status.setCreationDate(LocalDate.now());
         statusService.saveNewStatus(status);
         return ResponseEntity.ok(statusService.calculateStatusReport(status.getScore()));

--- a/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/DTO/CovidStatsDTO.java
+++ b/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/DTO/CovidStatsDTO.java
@@ -21,7 +21,6 @@ public class CovidStatsDTO {
     private Integer recovered;
     private Integer deaths;
     private Integer population;
-    private Object timeline;
 
 
 }

--- a/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Entities/Status.java
+++ b/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Entities/Status.java
@@ -21,7 +21,7 @@ public class Status {
     private int id;
 
     @Column(name = "score")
-    private Integer score;
+    private double score;
 
     @Column(name = "location")
     private String location;

--- a/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Services/StatusService.java
+++ b/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Services/StatusService.java
@@ -47,13 +47,13 @@ public class StatusService {
 
         double totalPopulation = covidStats.getPopulation();
         /**
-         * vaccineStats returns the total num of doses rolled out in a country(to-date)
-         * so assuming a double dose vaccine policy for each country the returned num is divided by 2
-         * therefore, administeredVax returns an approximate number of vaccines administered in a country
+         * vaccineStats returns the total num of doses administered in a country(to-date)
+         * so assuming a double dose vaccine policy ,the returned num is divided by 2
+         * therefore, popVaccinated returns an approximate number of people vaccinated(with double dose) in a country
          */
-        double administeredVax = vaccineStats.getTimeline().fields().next().getValue().asDouble() /2;
+        double popVaccinated = vaccineStats.getTimeline().fields().next().getValue().asDouble() /2;
 
-            return  (administeredVax/totalPopulation) * 100;
+            return  (popVaccinated/totalPopulation) * 100;
     }
 
     public String calculateStatusReport(double percentVaccinated) {

--- a/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Services/StatusService.java
+++ b/Project_2/LocationStatusAPI/src/main/java/com/Project_2_Location_Status_API/Services/StatusService.java
@@ -5,6 +5,7 @@ import com.Project_2_Location_Status_API.DTO.VaccineDataDTO;
 import com.Project_2_Location_Status_API.Entities.Status;
 import com.Project_2_Location_Status_API.Repositories.StatusRepository;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -28,7 +29,7 @@ public class StatusService {
     public void saveNewStatus(Status status) {
         if (status.getLocation() == null || status.getLocation().isEmpty()) {
             throw new NullPointerException("Can't create a status without a location");
-        } else if (status.getScore() == null || status.getScore() < 0) {
+        } else if (status.getScore() == 0 || status.getScore() < 0) {
             throw new NullPointerException("Can't create a status with a null or negative score");
         } else if (status.getCreationDate() == null) {
             throw new NullPointerException("Can't create a status with a null creation date");
@@ -39,20 +40,24 @@ public class StatusService {
         }
     }
 
-    public int calculateScore(CovidStatsDTO covidStats, VaccineDataDTO vaccineStats) {
-        if (covidStats == null || vaccineStats == null)
+    public double calculateScore(CovidStatsDTO covidStats, VaccineDataDTO vaccineStats) {
+        if (covidStats == null  || vaccineStats == null)
             throw new NullPointerException("No data found for country provided");
         Status status = new Status();
-        int numOfPopVaccinated = vaccineStats.getTimeline().fields().next().getValue().asInt();
-        int totalPopulation = covidStats.getPopulation();
-//        String status;
-        int percentVaccinated;
-        return percentVaccinated = (totalPopulation / numOfPopVaccinated) * 100;
+
+        double totalPopulation = covidStats.getPopulation();
+        /**
+         * vaccineStats returns the total num of doses rolled out in a country(to-date)
+         * so assuming a double dose vaccine policy for each country the returned num is divided by 2
+         * therefore, administeredVax returns an approximate number of vaccines administered in a country
+         */
+        double administeredVax = vaccineStats.getTimeline().fields().next().getValue().asDouble() /2;
+
+            return  (administeredVax/totalPopulation) * 100;
     }
 
-    public String calculateStatusReport(int percentVaccinated) {
+    public String calculateStatusReport(double percentVaccinated) {
 
-//
         if (percentVaccinated > 80) {
             return "Safe to travel";
         } else if (percentVaccinated > 40 && percentVaccinated < 80) {

--- a/Project_2/LocationStatusAPI/src/test/java/com/Project_2_Location_Status_API/Services/StatusServiceTest.java
+++ b/Project_2/LocationStatusAPI/src/test/java/com/Project_2_Location_Status_API/Services/StatusServiceTest.java
@@ -35,7 +35,7 @@ class StatusServiceTest {
 
     @Test
     public void shouldNotCreateNewStatusWithNullScore(){
-        Status status = new Status(1, null, "Spain",
+        Status status = new Status(1, 0, "Spain",
                 LocalDate.parse("2020-01-01"));
         when(mockStatusRepository.save(status)).thenReturn(status);
 


### PR DESCRIPTION
- The issue was with the data type being used for the calculation
- I was using int.
- in java, integer division rounds toward 0
- which is why the score was always zero
- I changed it to  a double
- [x] Bug fixed

I realized that the data being returned from the vaccine endpoint was returning total doses administered without taking into account that most countries have a double shot policy
So I refactored it as such:
- vaccineStats returns the total num of doses administered in a country(to-date)
-  so assuming a double dose vaccine policy ,the returned num is divided by 2
-   therefore, popVaccinated returns an approximate number of people vaccinated(with double dose) in a country

Try these:
SAFE:   USA, Canada, Japan
CAUTIOUS:  India, Russia
UNSAFE:   Lebanon, Egypt